### PR TITLE
docs: fix logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![LambdaTest Logo](https://www.lambdatest.com/static/images/logo.svg)
+![LambdaTest Logo](https://www.lambdatest.com/resources/images/logos/logo.svg)
 ---
 # Protractor Selenium Sample
 


### PR DESCRIPTION
The LambdaTest logo link was broken.This PR fixes that.